### PR TITLE
Updated ShakeBug sdk to latest 1.2.49 version along with README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Sign up for a service at https://www.shakebug.com
 Add this line to your build.gradle file. 
 
 ```groovy
-implementation 'com.softnoesis.shakebug:ShakeBug:1.2.48'
+implementation 'com.softnoesis.shakebug:ShakeBug:1.2.49'
 ```
 
 ## Usage

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,5 +35,5 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation 'com.softnoesis.shakebug:ShakeBug:1.2.48'
+    implementation 'com.softnoesis.shakebug:ShakeBug:1.2.49'
 }


### PR DESCRIPTION
New 1.2.49 version is now live and usable